### PR TITLE
fix: only accept directories when looking for files in resource patch

### DIFF
--- a/src/main/kotlin/app/revanced/cli/Patcher.kt
+++ b/src/main/kotlin/app/revanced/cli/Patcher.kt
@@ -6,6 +6,7 @@ import app.revanced.utils.patcher.applyPatchesPrint
 import app.revanced.utils.patcher.mergeFiles
 import app.revanced.utils.signing.Signer
 import java.io.File
+import java.io.FileFilter
 
 internal class Patcher {
     internal companion object {
@@ -30,7 +31,7 @@ internal class Patcher {
             }
 
             if (MainCommand.patchResources) {
-                for (file in File(MainCommand.cacheDirectory).resolve("build/").listFiles()?.first()?.listFiles()!!) {
+                for (file in File(MainCommand.cacheDirectory).resolve("build/").listFiles(FileFilter { it.isDirectory })?.first()?.listFiles()!!) {
                     if (!file.isDirectory) {
                         zipFileSystem.replaceFile(file.name, file.readBytes())
                         continue


### PR DESCRIPTION
If resource patching is enabled, ReVanced CLI looks for the first directory entry in the `build` directory of the cache directory and assumes that those directory entries are directories.

While it may always be the case that the first entry is a directory on Windows, this is not always the case on Linux where files may be listed before directories instead of them being ordered alphabetically.

This PR changes that functionality so that only directories are obtained so the first entry is always a directory (if such a directory exists).