### PR TITLE
Remove uneeded and error prone dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,6 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.21")
     implementation("app.revanced:revanced-patcher:1.0.0-dev.16")
-    implementation("app.revanced:revanced-patches:1.0.0-dev.11")
 
     implementation("info.picocli:picocli:4.6.3")
 


### PR DESCRIPTION
Removes the revanced-patcher dependency from revanced-cli, it wasn't used anyways.