### PR TITLE
Use the `/data/adb/magisk/busybox` from Magisk wherever possible

### DIFF
--- a/src/main/kotlin/app/revanced/utils/adb/Constants.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Constants.kt
@@ -42,18 +42,18 @@ internal object Constants {
         """
             #!/system/bin/sh
             
-            stock_path=${'$'}( pm path $PLACEHOLDER | grep base | sed 's/package://g' )
-            umount -l ${'$'}stock_path
+            stock_path=${'$'}( pm path $PLACEHOLDER | /data/adb/magisk/busybox grep base | /data/adb/magisk/busybox sed 's/package://g' )
+            /data/adb/magisk/busybox umount -l ${'$'}stock_path
         """.trimIndent()
 
     // mount script
     internal val CONTENT_MOUNT_SCRIPT =
         """
             #!/system/bin/sh
-            while [ "${'$'}(getprop sys.boot_completed | tr -d '\r')" != "1" ]; do sleep 1; done
+            while [ "${'$'}(getprop sys.boot_completed | tr -d '\r')" != "1" ]; do /data/adb/magisk/busybox sleep 1; done
             
             base_path="$PATH_REVANCED_APP"
             stock_path=${'$'}( pm path $PLACEHOLDER | grep base | sed 's/package://g' )
-            mount -o bind ${'$'}base_path ${'$'}stock_path
+            /data/adb/magisk/busybox mount -o bind ${'$'}base_path ${'$'}stock_path
         """.trimIndent()
 }

--- a/src/main/kotlin/app/revanced/utils/adb/Constants.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Constants.kt
@@ -50,10 +50,10 @@ internal object Constants {
     internal val CONTENT_MOUNT_SCRIPT =
         """
             #!/system/bin/sh
-            while [ "${'$'}(getprop sys.boot_completed | tr -d '\r')" != "1" ]; do /data/adb/magisk/busybox sleep 1; done
+            while [ "${'$'}(getprop sys.boot_completed | /data/adb/magisk/busybox tr -d '\r')" != "1" ]; do /data/adb/magisk/busybox sleep 1; done
             
             base_path="$PATH_REVANCED_APP"
-            stock_path=${'$'}( pm path $PLACEHOLDER | grep base | sed 's/package://g' )
+            stock_path=${'$'}( pm path $PLACEHOLDER | /data/adb/magisk/busybox grep base | /data/adb/magisk/busybox sed 's/package://g' )
             /data/adb/magisk/busybox mount -o bind ${'$'}base_path ${'$'}stock_path
         """.trimIndent()
 }


### PR DESCRIPTION
Remember, this is untested. I checked that each command exists and runs in the busysbox but i didn't install it to /data/adb/