### PR TITLE
Added chcon on mount to fix SELinux issues

### DIFF
--- a/src/main/kotlin/app/revanced/utils/adb/Constants.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Constants.kt
@@ -54,6 +54,7 @@ internal object Constants {
             
             base_path="$PATH_REVANCED_APP"
             stock_path=${'$'}( pm path $PLACEHOLDER | grep base | sed 's/package://g' )
+
             chcon u:object_r:apk_data_file:s0  ${'$'}base_path
             mount -o bind ${'$'}base_path ${'$'}stock_path
         """.trimIndent()

--- a/src/main/kotlin/app/revanced/utils/adb/Constants.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Constants.kt
@@ -54,6 +54,7 @@ internal object Constants {
             
             base_path="$PATH_REVANCED_APP"
             stock_path=${'$'}( pm path $PLACEHOLDER | grep base | sed 's/package://g' )
+            chcon u:object_r:apk_data_file:s0  ${'$'}base_path
             mount -o bind ${'$'}base_path ${'$'}stock_path
         """.trimIndent()
 }


### PR DESCRIPTION
Fix issues of ReVanced not launching after reboot, because of "permission denied". SELinux blocks the access if the file is not "declared" as an APK file.

See conversation on Discord, #support, thread "[root] ReVanced broken on reboot"