### PR TITLE
Install ReVanced(Root) as Magisk module

### DIFF
--- a/src/main/kotlin/app/revanced/utils/adb/Adb.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Adb.kt
@@ -31,6 +31,9 @@ internal class Adb(
         if (modeInstall) {
             PackageManager(device).install(file)
         } else {
+            // delete old files
+            device.run(Constants.COMMAND_REMOVE_OLD_FILES.replacePlaceholder())
+
             // push patched file
             device.copy(Constants.PATH_INIT_PUSH, file)
 
@@ -55,6 +58,14 @@ internal class Adb(
             )
             // install unmount script
             device.run(Constants.COMMAND_INSTALL_UMOUNT.replacePlaceholder())
+
+            // push magisk-module prop
+            device.createFile(
+                Constants.PATH_INIT_PUSH,
+                Constants.CONTENT_MODULE_PROP.replacePlaceholder()
+            )
+            // install magisk-module prop
+            device.run(Constants.COMMAND_INSTALL_PROP.replacePlaceholder())
 
             // unmount the apk for sanity
             device.run(Constants.PATH_UMOUNT.replacePlaceholder())

--- a/src/main/kotlin/app/revanced/utils/adb/Adb.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Adb.kt
@@ -53,7 +53,7 @@ internal class Adb(
                 Constants.PATH_INIT_PUSH,
                 Constants.CONTENT_UMOUNT_SCRIPT.replacePlaceholder()
             )
-            // install mount script
+            // install unmount script
             device.run(Constants.COMMAND_INSTALL_UMOUNT.replacePlaceholder())
 
             // unmount the apk for sanity

--- a/src/main/kotlin/app/revanced/utils/adb/Constants.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Constants.kt
@@ -11,21 +11,19 @@ internal object Constants {
     internal const val COMMAND_LOGCAT = "logcat -c && logcat | grep AndroidRuntime"
     internal const val COMMAND_RESTART = "monkey -p $PLACEHOLDER 1 && kill ${'$'}($COMMAND_PID_OF $PLACEHOLDER)"
 
-    // default mount file name
-    private const val NAME_MOUNT_SCRIPT = "mount_revanced_$PLACEHOLDER.sh"
-
     // initial directory to push files to via adb push
     internal const val PATH_INIT_PUSH = "/data/local/tmp/revanced.delete"
 
-    // revanced path
-    internal const val PATH_REVANCED = "/data/adb/revanced/"
+    // revanced module path
+    internal const val PATH_REVANCED = "/data/adb/modules/revanced"
 
     // revanced apk path
-    private const val PATH_REVANCED_APP = "$PATH_REVANCED$PLACEHOLDER.apk"
+    private const val PATH_REVANCED_APP = "$PATH_REVANCED/$PLACEHOLDER.apk"
 
     // (un)mount script paths
-    internal const val PATH_MOUNT = "/data/adb/service.d/$NAME_MOUNT_SCRIPT"
-    internal const val PATH_UMOUNT = "/data/adb/post-fs-data.d/un$NAME_MOUNT_SCRIPT"
+    internal const val PATH_MOUNT = "$PATH_REVANCED/service.sh"
+    internal const val PATH_UMOUNT = "$PATH_REVANCED/post-fs-data.sh"
+    private const val PATH_PROP = "$PATH_REVANCED/module.prop"
 
     // move to revanced apk path & set permissions
     internal const val COMMAND_PREPARE_MOUNT_APK =
@@ -36,6 +34,15 @@ internal object Constants {
 
     // install umount script & set permissions
     internal const val COMMAND_INSTALL_UMOUNT = "mv $PATH_INIT_PUSH $PATH_UMOUNT && $COMMAND_CHMOD_MOUNT $PATH_UMOUNT"
+
+    // install magisk-module prop
+    internal const val COMMAND_INSTALL_PROP = "mv $PATH_INIT_PUSH $PATH_PROP"
+
+    // remove old revanced files
+    private const val PATH_OLD_REVANCED_DIR = "/data/adb/revanced/"
+    private const val PATH_OLD_MOUNT = "/data/adb/service.d/mount_revanced_$PLACEHOLDER.sh"
+    private const val PATH_OLD_UNMOUNT = "/data/adb/post-fs-data.d/unmount_revanced_$PLACEHOLDER.sh"
+    internal const val COMMAND_REMOVE_OLD_FILES = "rm -rf $PATH_OLD_REVANCED_DIR $PATH_OLD_MOUNT $PATH_OLD_UNMOUNT"
 
     // unmount script
     internal val CONTENT_UMOUNT_SCRIPT =
@@ -57,5 +64,16 @@ internal object Constants {
 
             chcon u:object_r:apk_data_file:s0  ${'$'}base_path
             mount -o bind ${'$'}base_path ${'$'}stock_path
+        """.trimIndent()
+
+    // magisk-module prop
+    internal val CONTENT_MODULE_PROP =
+        """
+            id=revanced
+            name=ReVanced Magisk Module
+            version=1
+            versionCode=1
+            author=ReVanced
+            description=This is ReVanced Magisk-Module. You can uninstall ReVanced by deleting this module.
         """.trimIndent()
 }


### PR DESCRIPTION
・We can uninstall revanced easier through Magisk App.
This is necessary for usability.
[Magisk App]
<img src=https://user-images.githubusercontent.com/107102326/174324987-56dd24c8-5a92-40f5-8fb0-68c6ee21a178.png width="200px">

・Install Revanced in Magisk module folder
[Magisk Official Guides](https://topjohnwu.github.io/Magisk/guides.html)
https://github.com/revanced/revanced-cli/blob/d98269d3ce92c3a0ed2f09d338aa1b4fd384e38e/src/main/kotlin/app/revanced/utils/adb/Constants.kt#L17-L26
https://github.com/revanced/revanced-cli/blob/d98269d3ce92c3a0ed2f09d338aa1b4fd384e38e/src/main/kotlin/app/revanced/utils/adb/Constants.kt#L69-L78

・To prevent trouble, old mount scripts in mobile will be removed, automatically.
https://github.com/revanced/revanced-cli/blob/d98269d3ce92c3a0ed2f09d338aa1b4fd384e38e/src/main/kotlin/app/revanced/utils/adb/Constants.kt#L41-L45
https://github.com/revanced/revanced-cli/blob/d98269d3ce92c3a0ed2f09d338aa1b4fd384e38e/src/main/kotlin/app/revanced/utils/adb/Adb.kt#L34-L35
Please adjust the code. Thanks.