### PR TITLE
feat: DefaultCliLogger now logs to stdOut and stdErr

### DIFF
--- a/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
+++ b/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
@@ -7,13 +7,13 @@ import java.util.logging.SimpleFormatter
 import java.util.logging.StreamHandler
 
 internal class DefaultCliLogger(
-    private val stdOutLogger: Logger = Logger.getLogger(MainCommand::javaClass.name),
-    private val stdErrLogger: Logger = Logger.getLogger(MainCommand::javaClass.name + "Err")
+    private val logger: Logger = Logger.getLogger(MainCommand::javaClass.name),
+    private val errorLogger: Logger = Logger.getLogger(MainCommand::javaClass.name + "Err")
 ) : CliLogger {
 
     init {
-        stdOutLogger.useParentHandlers = false
-        stdOutLogger.addHandler(StreamHandler(System.out, SimpleFormatter()))
+        logger.useParentHandlers = false
+        logger.addHandler(StreamHandler(System.out, SimpleFormatter()))
     }
     companion object {
         init {
@@ -21,8 +21,8 @@ internal class DefaultCliLogger(
         }
     }
 
-    override fun error(msg: String) = stdErrLogger.severe(msg)
-    override fun info(msg: String) = stdOutLogger.info(msg)
-    override fun trace(msg: String) = stdOutLogger.finest(msg)
-    override fun warn(msg: String) = stdErrLogger.warning(msg)
+    override fun error(msg: String) = errorLogger.severe(msg)
+    override fun info(msg: String) = logger.info(msg)
+    override fun trace(msg: String) = logger.finest(msg)
+    override fun warn(msg: String) = errorLogger.warning(msg)
 }

--- a/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
+++ b/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
@@ -3,18 +3,26 @@ package app.revanced.cli.logging.impl
 import app.revanced.cli.command.MainCommand
 import app.revanced.cli.logging.CliLogger
 import java.util.logging.Logger
+import java.util.logging.SimpleFormatter
+import java.util.logging.StreamHandler
 
 internal class DefaultCliLogger(
-    private val logger: Logger = Logger.getLogger(MainCommand::javaClass.name)
+    private val stdOutLogger: Logger = Logger.getLogger(MainCommand::javaClass.name),
+    private val stdErrLogger: Logger = Logger.getLogger(MainCommand::javaClass.name + "Err")
 ) : CliLogger {
+
+    init {
+        stdOutLogger.useParentHandlers = false
+        stdOutLogger.addHandler(StreamHandler(System.out, SimpleFormatter()))
+    }
     companion object {
         init {
             System.setProperty("java.util.logging.SimpleFormatter.format", "%4\$s: %5\$s %n")
         }
     }
 
-    override fun error(msg: String) = logger.severe(msg)
-    override fun info(msg: String) = logger.info(msg)
-    override fun trace(msg: String) = logger.finest(msg)
-    override fun warn(msg: String) = logger.warning(msg)
+    override fun error(msg: String) = stdErrLogger.severe(msg)
+    override fun info(msg: String) = stdOutLogger.info(msg)
+    override fun trace(msg: String) = stdOutLogger.finest(msg)
+    override fun warn(msg: String) = stdErrLogger.warning(msg)
 }


### PR DESCRIPTION
Implements #62 
Made DefaultCliLogger to log trace, info to stdOut and warn, error to stdErr.

This PR marked as draft because it's kind of "hacky". It's created to decide if we need this feature right now, or it can be implemented later differently (e.g. using different logging backend)