### PR TITLE
ci: trigger release on `build` commits

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,11 @@
     }
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    ["@semantic-release/commit-analyzer", {
+      "releaseRules": [
+        {"type": "build", "release": "patch"}
+      ]
+    }],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "gradle-semantic-release-plugin",


### PR DESCRIPTION
to automatically create a release when e.g. a dependency get's updated

related: https://github.com/orgs/revanced/discussions/261#discussioncomment-3027167
![image](https://user-images.githubusercontent.com/55899582/175831940-592a0445-8142-4570-94c0-49d2638a6d67.png)