### PR TITLE
fix: Log not showing in CLI 

### DIFF
--- a/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
+++ b/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
@@ -12,8 +12,10 @@ internal class DefaultCliLogger(
 
     init {
         logger.useParentHandlers = false
+        logger.handlers.forEach { logger.removeHandler(it) }
         logger.addHandler(FlushingStreamHandler(System.out, SimpleFormatter()))
     }
+
     companion object {
         init {
             System.setProperty("java.util.logging.SimpleFormatter.format", "%4\$s: %5\$s %n")

--- a/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
+++ b/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
@@ -7,13 +7,14 @@ import java.util.logging.SimpleFormatter
 
 internal class DefaultCliLogger(
     private val logger: Logger = Logger.getLogger(MainCommand::javaClass.name),
-    private val errorLogger: Logger = Logger.getLogger(MainCommand::javaClass.name + "Err")
+    private val errorLogger: Logger = Logger.getLogger(logger.name + "Err")
 ) : CliLogger {
 
     init {
         logger.useParentHandlers = false
-        logger.handlers.forEach { logger.removeHandler(it) }
-        logger.addHandler(FlushingStreamHandler(System.out, SimpleFormatter()))
+        if (logger.handlers.isEmpty()) {
+            logger.addHandler(FlushingStreamHandler(System.out, SimpleFormatter()))
+        }
     }
 
     companion object {

--- a/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
+++ b/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
@@ -4,7 +4,6 @@ import app.revanced.cli.command.MainCommand
 import app.revanced.cli.logging.CliLogger
 import java.util.logging.Logger
 import java.util.logging.SimpleFormatter
-import java.util.logging.StreamHandler
 
 internal class DefaultCliLogger(
     private val logger: Logger = Logger.getLogger(MainCommand::javaClass.name),
@@ -13,7 +12,7 @@ internal class DefaultCliLogger(
 
     init {
         logger.useParentHandlers = false
-        logger.addHandler(StreamHandler(System.out, SimpleFormatter()))
+        logger.addHandler(FlushingStreamHandler(System.out, SimpleFormatter()))
     }
     companion object {
         init {

--- a/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
+++ b/src/main/kotlin/app/revanced/cli/logging/impl/DefaultCliLogger.kt
@@ -6,7 +6,7 @@ import java.util.logging.Logger
 import java.util.logging.SimpleFormatter
 
 internal class DefaultCliLogger(
-    private val logger: Logger = Logger.getLogger(MainCommand::javaClass.name),
+    private val logger: Logger = Logger.getLogger(MainCommand::class.java.name),
     private val errorLogger: Logger = Logger.getLogger(logger.name + "Err")
 ) : CliLogger {
 

--- a/src/main/kotlin/app/revanced/cli/logging/impl/FlushingStreamHandler.kt
+++ b/src/main/kotlin/app/revanced/cli/logging/impl/FlushingStreamHandler.kt
@@ -1,0 +1,13 @@
+package app.revanced.cli.logging.impl
+
+import java.io.OutputStream
+import java.util.logging.Formatter
+import java.util.logging.LogRecord
+import java.util.logging.StreamHandler
+
+internal class FlushingStreamHandler(out: OutputStream, format: Formatter) : StreamHandler(out, format) {
+    override fun publish(record: LogRecord) {
+        super.publish(record)
+        flush()
+    }
+}

--- a/src/main/kotlin/app/revanced/cli/patcher/logging/impl/PatcherLogger.kt
+++ b/src/main/kotlin/app/revanced/cli/patcher/logging/impl/PatcherLogger.kt
@@ -4,7 +4,7 @@ import app.revanced.cli.logging.impl.DefaultCliLogger
 import java.util.logging.Logger
 
 internal object PatcherLogger : app.revanced.patcher.logging.Logger{
-    private val logger = DefaultCliLogger(Logger.getLogger(app.revanced.patcher.Patcher::javaClass.name))
+    private val logger = DefaultCliLogger(Logger.getLogger(app.revanced.patcher.Patcher::class.java.name))
 
     override fun error(msg: String) = logger.error(msg)
     override fun info(msg: String) = logger.info(msg)


### PR DESCRIPTION
My implementation of #62  added two loggers where one use StreamHandler with stdout to separate output of different values to different pipes (stdout and stderr).
But it seems that stdout logger wasn't flushed properly. 
This PR should fix it by introducing FlushingStreamHandler which flushes after every log message.

This PR was not yet tested, because currently I can't test it, but I will do so as soon as possible (probably in 24 hours)