### PR TITLE
refactor: adapt to patcher changes

### DIFF
--- a/src/main/kotlin/app/revanced/cli/command/MainCommand.kt
+++ b/src/main/kotlin/app/revanced/cli/command/MainCommand.kt
@@ -10,7 +10,7 @@ import app.revanced.patcher.PatcherOptions
 import app.revanced.patcher.extensions.PatchExtensions.compatiblePackages
 import app.revanced.patcher.extensions.PatchExtensions.description
 import app.revanced.patcher.extensions.PatchExtensions.patchName
-import app.revanced.patcher.util.patch.implementation.JarPatchBundle
+import app.revanced.patcher.util.patch.impl.JarPatchBundle
 import app.revanced.utils.adb.Adb
 import picocli.CommandLine.*
 import java.io.File

--- a/src/main/kotlin/app/revanced/cli/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/cli/patcher/Patcher.kt
@@ -30,7 +30,7 @@ internal object Patcher {
             // replace all dex files
             result.dexFiles.forEach {
                 logger.info("Writing dex file ${it.name}")
-                outputFileSystem.write(it.name, it.dexFileInputStream.readAllBytes())
+                outputFileSystem.write(it.name, it.stream.readAllBytes())
             }
 
             if (!args.disableResourcePatching) {

--- a/src/main/kotlin/app/revanced/utils/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/utils/patcher/Patcher.kt
@@ -9,7 +9,7 @@ import app.revanced.patcher.extensions.PatchExtensions.compatiblePackages
 import app.revanced.patcher.extensions.PatchExtensions.include
 import app.revanced.patcher.extensions.PatchExtensions.patchName
 import app.revanced.patcher.patch.Patch
-import app.revanced.patcher.util.patch.implementation.JarPatchBundle
+import app.revanced.patcher.util.patch.impl.JarPatchBundle
 
 fun Patcher.addPatchesFiltered() {
     val packageName = this.data.packageMetadata.packageName


### PR DESCRIPTION
makes cli compatible with latest patcher
cli build fails since https://github.com/revanced/revanced-patcher/commit/01cf3fb50f66748e2665d93fc5fa4c32eef3ab96
