### PR TITLE
fix: listing patches requires input apk again

### DIFF
--- a/src/main/kotlin/app/revanced/cli/command/MainCommand.kt
+++ b/src/main/kotlin/app/revanced/cli/command/MainCommand.kt
@@ -132,8 +132,9 @@ internal object MainCommand : Runnable {
             printListOfPatches()
             return
         }
+
         if (args.uArgs?.uninstall == true) {
-            uninstall()
+            Adb(args.uArgs?.deploy!!).uninstall()
             return
         }
 
@@ -210,10 +211,6 @@ internal object MainCommand : Runnable {
         else
             "Failed to clean up cache directory"
         logger.info(result)
-    }
-
-    private fun uninstall() {
-        Adb(args.uArgs?.deploy!!).uninstall()
     }
 
     private fun printListOfPatches() {

--- a/src/main/kotlin/app/revanced/cli/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/cli/patcher/Patcher.kt
@@ -11,7 +11,7 @@ import java.nio.file.Files
 
 internal object Patcher {
     internal fun start(patcher: app.revanced.patcher.Patcher, output: File) {
-        val args = args.pArgs ?: return
+        val args = args.cArgs?.pArgs ?: return
 
         // merge files like necessary integrations
         patcher.mergeFiles()

--- a/src/main/kotlin/app/revanced/cli/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/cli/patcher/Patcher.kt
@@ -11,8 +11,7 @@ import java.nio.file.Files
 
 internal object Patcher {
     internal fun start(patcher: app.revanced.patcher.Patcher, output: File) {
-        val inputFile = args.inputFile
-        val args = args.patchArgs?.patchingArgs!!
+        val args = args.pArgs ?: return
 
         // merge files like necessary integrations
         patcher.mergeFiles()
@@ -23,7 +22,7 @@ internal object Patcher {
 
         // write output file
         if (output.exists()) Files.delete(output.toPath())
-        inputFile.copyTo(output)
+        args.inputFile.copyTo(output)
 
         val result = patcher.save()
         ZipFileSystemUtils(output).use { outputFileSystem ->

--- a/src/main/kotlin/app/revanced/utils/adb/Adb.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Adb.kt
@@ -8,12 +8,19 @@ import java.io.File
 import java.util.concurrent.Executors
 
 internal class Adb(
-    private val file: File,
+    private val file: File? = null,
     private val packageName: String,
     deviceName: String,
     private val modeInstall: Boolean = false,
     private val logging: Boolean = true
 ) {
+    constructor(deviceName: String, packageName: String): this(
+        null,
+        packageName,
+        deviceName,
+        false
+    )
+
     private val device: JadbDevice
 
     init {
@@ -37,7 +44,7 @@ internal class Adb(
             logger.info("Installing by mounting")
 
             // push patched file
-            device.copy(Constants.PATH_INIT_PUSH, file)
+            device.copy(Constants.PATH_INIT_PUSH, file!!)
 
             // create revanced folder path
             device.run("${Constants.COMMAND_CREATE_DIR} ${Constants.PATH_REVANCED}")

--- a/src/main/kotlin/app/revanced/utils/adb/Adb.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Adb.kt
@@ -9,14 +9,14 @@ import java.util.concurrent.Executors
 
 internal class Adb(
     private val file: File? = null,
-    private val packageName: String,
+    private var packageName: String,
     deviceName: String,
     private val modeInstall: Boolean = false,
     private val logging: Boolean = true
 ) {
-    constructor(deviceName: String, packageName: String): this(
+    constructor(deviceName: String): this(
         null,
-        packageName,
+        Constants.PLACEHOLDER,
         deviceName,
         false
     )

--- a/src/main/kotlin/app/revanced/utils/adb/Adb.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Adb.kt
@@ -87,7 +87,7 @@ internal class Adb(
         }
 
         println("Which app do you want to uninstall?")
-        val fileToUninstall = readLine()!!.toInt()
+        val fileToUninstall = readln().toInt()
         packageName = File(fileList[fileToUninstall]).nameWithoutExtension
 
         logger.info("Uninstalling $packageName by unmounting")

--- a/src/main/kotlin/app/revanced/utils/adb/Adb.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Adb.kt
@@ -80,10 +80,10 @@ internal class Adb(
         device.run(Constants.COMMAND_UMOUNT.replacePlaceholder())
 
         // delete revanced app
-        device.run(Constants.COMMAND_DELETE.replacePlaceholder(Constants.PATH_REVANCED_APP).replacePlaceholder())
+        device.delete(Constants.PATH_REVANCED_APP.replacePlaceholder())
 
         // delete mount script
-        device.run(Constants.COMMAND_DELETE.replacePlaceholder(Constants.PATH_MOUNT).replacePlaceholder())
+        device.delete(Constants.PATH_MOUNT.replacePlaceholder())
 
         logger.info("Finished uninstalling")
     }

--- a/src/main/kotlin/app/revanced/utils/adb/Adb.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Adb.kt
@@ -18,7 +18,7 @@ internal class Adb(
         null,
         Constants.PLACEHOLDER,
         deviceName,
-        false
+        true
     )
 
     private val device: JadbDevice
@@ -74,8 +74,23 @@ internal class Adb(
     }
 
     internal fun uninstall() {
-        logger.info("Uninstalling by unmounting")
+        val adbLookupFiles = device.buildCommand("ls ${Constants.PATH_REVANCED}").start()
+        val inputStreamReader = adbLookupFiles.inputReader()
 
+        val fileList = inputStreamReader.readLines()
+        if (fileList.isEmpty()) {
+            logger.error("No mounted apps found")
+            return
+        }
+        fileList.forEachIndexed { index, file ->
+            println("$index: $file")
+        }
+
+        println("Which app do you want to uninstall?")
+        val fileToUninstall = readLine()!!.toInt()
+        packageName = File(fileList[fileToUninstall]).nameWithoutExtension
+
+        logger.info("Uninstalling $packageName by unmounting")
         // unmount the apk
         device.run(Constants.COMMAND_UMOUNT.replacePlaceholder())
 

--- a/src/main/kotlin/app/revanced/utils/adb/Commands.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Commands.kt
@@ -27,3 +27,7 @@ internal fun JadbDevice.copy(targetPath: String, file: File) {
 internal fun JadbDevice.createFile(targetFile: String, content: String) {
     push(content.byteInputStream(), System.currentTimeMillis(), 644, RemoteFile(targetFile))
 }
+
+internal fun JadbDevice.delete(targetPath: String) {
+    this.buildCommand("rm -rf $targetPath").start().waitFor()
+}

--- a/src/main/kotlin/app/revanced/utils/adb/Constants.kt
+++ b/src/main/kotlin/app/revanced/utils/adb/Constants.kt
@@ -23,9 +23,6 @@ internal object Constants {
     // revanced apk path
     internal const val PATH_REVANCED_APP = "$PATH_REVANCED$PLACEHOLDER.apk"
 
-    // delete command
-    internal const val COMMAND_DELETE = "rm -rf $PLACEHOLDER"
-
     // mount script path
     internal const val PATH_MOUNT = "/data/adb/service.d/$NAME_MOUNT_SCRIPT"
 

--- a/src/main/kotlin/app/revanced/utils/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/utils/patcher/Patcher.kt
@@ -15,7 +15,7 @@ fun Patcher.addPatchesFiltered() {
     val packageName = this.data.packageMetadata.packageName
     val packageVersion = this.data.packageMetadata.packageVersion
 
-    args.patchArgs?.patchBundles!!.forEach { bundle ->
+    args.lArgsParent?.patchBundles?.forEach { bundle ->
         val includedPatches = mutableListOf<Class<out Patch<Data>>>()
         JarPatchBundle(bundle).loadPatches().forEach patch@{ patch ->
             val compatiblePackages = patch.compatiblePackages
@@ -23,7 +23,7 @@ fun Patcher.addPatchesFiltered() {
 
             val prefix = "Skipping $patchName"
 
-            val args = MainCommand.args.patchArgs?.patchingArgs!!
+            val args = MainCommand.args.pArgs ?: return
 
             if (args.excludedPatches.contains(patchName)) {
                 logger.info("$prefix: Explicitly excluded")
@@ -72,7 +72,7 @@ fun Patcher.applyPatchesVerbose() {
 }
 
 fun Patcher.mergeFiles() {
-    this.addFiles(args.patchArgs?.patchingArgs!!.mergeFiles) { file ->
+    this.addFiles(args.pArgs!!.mergeFiles) { file ->
         logger.info("Merging $file")
     }
 }

--- a/src/main/kotlin/app/revanced/utils/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/utils/patcher/Patcher.kt
@@ -15,7 +15,7 @@ fun Patcher.addPatchesFiltered() {
     val packageName = this.data.packageMetadata.packageName
     val packageVersion = this.data.packageMetadata.packageVersion
 
-    args.lArgsParent?.patchBundles?.forEach { bundle ->
+    args.cArgs?.patchBundles?.forEach { bundle ->
         val includedPatches = mutableListOf<Class<out Patch<Data>>>()
         JarPatchBundle(bundle).loadPatches().forEach patch@{ patch ->
             val compatiblePackages = patch.compatiblePackages
@@ -23,7 +23,7 @@ fun Patcher.addPatchesFiltered() {
 
             val prefix = "Skipping $patchName"
 
-            val args = MainCommand.args.pArgs ?: return
+            val args = MainCommand.args.cArgs?.pArgs ?: return
 
             if (args.excludedPatches.contains(patchName)) {
                 logger.info("$prefix: Explicitly excluded")
@@ -45,9 +45,9 @@ fun Patcher.addPatchesFiltered() {
                 }
 
                 if (!(args.experimental || compatiblePackages.any { it.versions.isEmpty() || it.versions.any { version -> version == packageVersion } })) {
-                    val compatibleWith = compatiblePackages.map { _package ->
+                    val compatibleWith = compatiblePackages.joinToString(";") { _package ->
                         "${_package.name}: ${_package.versions.joinToString(", ")}"
-                    }.joinToString(";")
+                    }
                     logger.warn("$prefix: Incompatible with version $packageVersion. This patch is only compatible with version $compatibleWith")
                     return@patch
                 }
@@ -72,7 +72,7 @@ fun Patcher.applyPatchesVerbose() {
 }
 
 fun Patcher.mergeFiles() {
-    this.addFiles(args.pArgs!!.mergeFiles) { file ->
+    this.addFiles(args.cArgs?.pArgs!!.mergeFiles) { file ->
         logger.info("Merging $file")
     }
 }


### PR DESCRIPTION
Fixes #87 the correct way. This reimplents the uninstallation process to be more interactable.
*This now forces `-d, deploy-on` flag to be required when using `--uninstall` flag to avoid it doing nothing. 