### PR TITLE
feat: trace logs when compatibility annotation is missing

### DIFF
--- a/src/main/kotlin/app/revanced/utils/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/utils/patcher/Patcher.kt
@@ -31,7 +31,7 @@ fun Patcher.addPatchesFiltered(allPatches: List<Class<out Patch<Context>>>) {
             return@patchLoop
         }
 
-        if (compatiblePackages == null) logger.warn("$prefix: Missing compatibility annotation. Continuing.")
+        if (compatiblePackages == null) logger.trace("$prefix: Missing compatibility annotation. Continuing.")
         else {
             if (!compatiblePackages.any { it.name == packageName }) {
                 logger.trace("$prefix: Incompatible with $packageName. This patch is only compatible with ${


### PR DESCRIPTION
This PR uses tracing logs when the compatibility annotation is missing instead of warning about it. 