### PR TITLE
docs: fix misspelling word

### DIFF
--- a/docs/1_usage.md
+++ b/docs/1_usage.md
@@ -1,6 +1,6 @@
 # 🛠️ Using the ReVanced CLI
 
-Lean how to use the ReVanced CLI.
+Learn how to use the ReVanced CLI.
 
 ## ⚡ Setup (optional)
 


### PR DESCRIPTION
## 📝 Fix misspelling word

_Fix misspelling or typo, or something_

The word "Learn" has been spell as "Lean" which is incorrect.