### PR TITLE
build(Needs bump): Bump dependencies to support `PatchOption#valueType`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ shadow = "8.1.1"
 kotlin-test = "1.8.20-RC"
 kotlinx-coroutines-core = "1.7.3"
 picocli = "4.7.3"
-revanced-patcher = "18.0.0"
+revanced-patcher = "19.0.0"
 revanced-library = "1.1.5"
 
 [libraries]


### PR DESCRIPTION
As requested: bumping patcher to 19.
Introducing a breaking change; hopefully this won't cause the patches to explode.