### PR TITLE
feat: List patches which are compatible with any app

### DIFF
--- a/src/main/kotlin/app/revanced/cli/command/ListPatchesCommand.kt
+++ b/src/main/kotlin/app/revanced/cli/command/ListPatchesCommand.kt
@@ -47,6 +47,13 @@ internal object ListPatchesCommand : Runnable {
     )
     private var packageName: String? = null
 
+    @Option(
+        names = ["--filter-include-packageless"],
+        description = ["Include patches with no compatible packages listed when filtering by package name."],
+        showDefaultValue = ALWAYS
+    )
+    private var patchesWithNoPackage: Boolean = false
+
     override fun run() {
         fun Patch.CompatiblePackage.buildString() = buildString {
             if (withVersions && versions != null) {
@@ -92,7 +99,7 @@ internal object ListPatchesCommand : Runnable {
             }
         }
 
-        fun Patch<*>.anyPackageName(name: String) = compatiblePackages?.any { it.name == name } == true
+        fun Patch<*>.anyPackageName(name: String) = compatiblePackages?.any { it.name == name } ?: patchesWithNoPackage
 
         val patches = PatchBundleLoader.Jar(*patchBundles)
 


### PR DESCRIPTION
The following patches from [revanced patches v2.195.0](https://github.com/ReVanced/revanced-patches/releases/tag/v2.195.0) have their `compatiblePackages: Set<CompatiblePackage>?` set to `null`:

- Remove screen capture restriction
- Export all activities
- Remove screenshot restriction
- Enable Android debugging
- Override certificate pinning
- Change package name
- Predictive back gesture
- Spoof Wi-Fi connection

which, I assume, means they are universal and not application-specific. So I added an option to list those too when filtering by package name.