### PR TITLE
docs: List supported ABIs correctly and add a mention how to use other ones

### DIFF
--- a/docs/0_prerequisites.md
+++ b/docs/0_prerequisites.md
@@ -6,7 +6,7 @@ To use ReVanced CLI, you will need to fulfill specific requirements.
 
 - Java Runtime Environment 11 ([Azul Zulu JRE](https://www.azul.com/downloads/?version=java-11-lts&package=jre#zulu) or [OpenJDK](https://jdk.java.net/archive/))
 - [Android Debug Bridge (ADB)](https://developer.android.com/studio/command-line/adb) if you want to install the patched APK file on your device
-- x86 or x86-64 (For other architectures such as ARM, get a custom AAPT binary that supports your architecture and provide it with `--custom-aapt2-binary` option)
+- x86 or x86-64 (For [other architectures](https://github.com/ReVanced/revanced-manager/tree/main/android/app/src/main/jniLibs) use the `--custom-aapt2-binary` option)
 
 ## ⏭️ Whats next
 

--- a/docs/0_prerequisites.md
+++ b/docs/0_prerequisites.md
@@ -6,7 +6,7 @@ To use ReVanced CLI, you will need to fulfill specific requirements.
 
 - Java Runtime Environment 11 ([Azul Zulu JRE](https://www.azul.com/downloads/?version=java-11-lts&package=jre#zulu) or [OpenJDK](https://jdk.java.net/archive/))
 - [Android Debug Bridge (ADB)](https://developer.android.com/studio/command-line/adb) if you want to install the patched APK file on your device
-- An ABI other than ARMv7 such as x86 or x86-64 (or a custom AAPT binary that supports ARMv7)
+- x86 or x86-64 (For other architectures such as ARM, get a custom AAPT binary that supports your architecture and provide it with `--custom-aapt2-binary` option)
 
 ## ⏭️ Whats next
 


### PR DESCRIPTION
It said that an ABI other than ARMv7 is supported, but ARMv8 isn't supported as well
(ReVanced CLI only contains x86 and x86-64 of aapt2)
This PR corrects this
And clarify the way to use a custom AAPT binary