### PR TITLE
build: Remove AAPT1 binary & minimize ReVanced Library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,10 +59,14 @@ tasks {
     }
 
     shadowJar {
+        exclude("/prebuilt/linux/aapt")
+        exclude("/prebuilt/linux/aapt_64")
+        exclude("/prebuilt/macosx/aapt_64")
+        exclude("/prebuilt/windows/aapt.exe")
+        exclude("/prebuilt/windows/aapt_64.exe")
         minimize {
-            exclude(dependency("org.jetbrains.kotlin:.*"))
             exclude(dependency("org.bouncycastle:.*"))
-            exclude(dependency("app.revanced:.*"))
+            exclude(dependency("app.revanced:revanced-patcher"))
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,11 +59,7 @@ tasks {
     }
 
     shadowJar {
-        exclude("/prebuilt/linux/aapt")
-        exclude("/prebuilt/linux/aapt_64")
-        exclude("/prebuilt/macosx/aapt_64")
-        exclude("/prebuilt/windows/aapt.exe")
-        exclude("/prebuilt/windows/aapt_64.exe")
+        exclude("/prebuilt/linux/aapt", "/prebuilt/windows/aapt.exe", "/prebuilt/*/aapt_*")
         minimize {
             exclude(dependency("org.bouncycastle:.*"))
             exclude(dependency("app.revanced:revanced-patcher"))


### PR DESCRIPTION
First, exclude aapt1 binaries.
aapt1 is never used in ReVanced CLI, but accounts for 10% of the jar size.

Second, specify `app.revanced:revanced-patcher` explicitly in the minimize block, because revanced-library does not need to be excluded from minimization.
Since ReVanced Library was born, `exclude(dependency("app.revanced:.*"))` has been excluding revanced-library from minimization unintentionally.
(This line exists before ReVanced Library was created.)

I tested patching, list patches, list versions, mount/unmount, and install/uninstall. It worked as expected.

Finally, remove `exclude(dependency("org.jetbrains.kotlin:.*"))` as it has no effect.  Removing or adding this line made no difference.

This PR reduces the jar size as follows:
Removing aapt1: 49.9 MB -> 44.8 MB
Optimize minimization: 44.8 MB -> 40.3 MB