### PR TITLE
Bumped version number of revanced-library to match current release.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.0.20"
 kotlinx = "1.8.1"
 picocli = "4.7.6"
 revanced-patcher = "21.0.0"
-revanced-library = "3.0.2"
+revanced-library = "3.1.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
Fixes #355 
Many users on the Discord are reporting issues opening patched apps, especially YouTube, and this fixed it on my machine.