### PR TITLE
fix: Group `mount` and `install` options into an argument group 

### DIFF
--- a/src/main/kotlin/app/revanced/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/revanced/cli/command/PatchCommand.kt
@@ -255,7 +255,7 @@ internal object PatchCommand : Runnable {
             val deviceSerial = installation?.deviceSerial!!.ifEmpty { null }
 
             try {
-                if (installation?.mount ?: false) {
+                if (installation?.mount == true) {
                     AdbRootInstaller(deviceSerial)
                 } else {
                     AdbInstaller(deviceSerial)

--- a/src/main/kotlin/app/revanced/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/revanced/cli/command/PatchCommand.kt
@@ -123,7 +123,7 @@ internal object PatchCommand : Runnable {
             names = ["-i", "--install"],
             required = true,
             description = ["Serial of the ADB device to install to. If not specified, the first connected device will be used."],
-            fallbackValue = "",  // Empty string to indicate that the first connected device should be used.
+            fallbackValue = "",  // Empty string is used to select the first of connected devices.
             arity = "0..1",
         )
         internal var deviceSerial: String? = null


### PR DESCRIPTION
- make using `--mount` option in 'patch' command require the inclusion of `-i/--install` option.
- as it stands, if `-i` is not provided, then `--mount` flag is really not toggling the installation and user is left oblivious whether the patched apk is being installed or not