### PR TITLE
fix: Don't require the install flag

### DIFF
--- a/src/main/kotlin/app/revanced/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/revanced/cli/command/PatchCommand.kt
@@ -156,7 +156,6 @@ internal object PatchCommand : Callable<Int> {
     private class Installation {
         @CommandLine.Option(
             names = ["-i", "--install"],
-            required = true,
             description = ["Serial of the ADB device to install to. If not specified, the first connected device will be used."],
             fallbackValue = "",
             arity = "0..1",


### PR DESCRIPTION
Hi, I've noticed in recent builds that we can't use the cli to patch an APK without installing it to a device anymore. This PR reverts the `required: true` added on the `--install` option when it was grouped with the  `--mount` option. Doing so allows back patching without installing.