### PR TITLE
docs: add beginner-friendly CLI usage guide and update ToC

### DIFF
--- a/docs/0_prerequisites.md
+++ b/docs/0_prerequisites.md
@@ -1,15 +1,62 @@
 # 💼 Prerequisites
 
-To use ReVanced CLI, you will need to fulfill specific requirements.
+You'll need a few things set up on your PC before starting:
 
-## 🤝 Requirements
+- **Java Runtime Environment (JRE)** — the CLI tool runs on Java, so this is a must
+- **`wget`** — for downloading files from the terminal. Windows users can skip this, there's a browser method explained below
+- **`grep`** — optional, but makes searching through command output much easier. Windows users don't need it either
+- Some basic comfort with using a terminal or command prompt helps, but you don't need to be an expert
 
-- Java Runtime Environment 11 ([Azul Zulu JRE](https://www.azul.com/downloads/?version=java-11-lts&package=jre#zulu) or [OpenJDK](https://jdk.java.net/archive/))
-- [Android Debug Bridge (ADB)](https://developer.android.com/studio/command-line/adb) if you want to install the patched APK file on your device
-- x86 or x86-64 (For [other architectures](https://github.com/ReVanced/revanced-manager/tree/main/android/app/src/main/jniLibs) use the `--custom-aapt2-binary` option)
+---
+
+## Step 0: Install Java
+
+You need Java installed before anything else will work. Here's how to get it depending on your OS.
+
+### Windows
+
+Download and install **Eclipse Temurin** from [adoptium.net](https://adoptium.net/). This is the industry-standard build of OpenJDK and what most developers use. During installation, make sure to check the option that says **"Add to PATH"** so your terminal can find it.
+
+Once installed, open PowerShell and run:
+
+```powershell
+java -version
+```
+
+You should see something like `openjdk version "21.x.x"`. If you do, you're good to go.
+
+### Ubuntu / Debian / Mint / Pop!\_OS / Elementary / Zorin
+
+```bash
+sudo apt install openjdk-21-jre
+```
+
+### Fedora
+
+```bash
+sudo dnf install java-21-openjdk
+```
+
+### Arch / CachyOS / EndeavourOS / Manjaro
+
+```bash
+sudo pacman -S jre-openjdk
+```
+
+### Check it's installed (Linux / macOS)
+
+```bash
+java -version
+```
+
+Same as Windows, you should see an OpenJDK version printed out. Most Linux distros actually come with Java pre-installed, so there's a good chance this already works before you install anything.
 
 ## ⏭️ Whats next
 
 The following section will show you how to use ReVanced CLI.
 
 Continue: [🛠️ Using ReVanced CLI](1_usage.md)
+
+New to this. Check out the beginner friendly guide instead.
+
+Continue: [🛠️ Using ReVanced CLI (Beginner Guide)](1b_usage_beginners.md)

--- a/docs/1b_usage_beginners.md
+++ b/docs/1b_usage_beginners.md
@@ -1,0 +1,205 @@
+## Step 1: Download the ReVanced CLI
+
+Head over to the [ReVanced CLI releases page](https://github.com/ReVanced/revanced-cli/releases) and grab the latest `.jar` file.
+
+Create a new folder somewhere easy to find (something like `revanced` on your Desktop works fine), drop the file in there, and rename it to:
+
+```
+revanced-cli.jar
+```
+
+Now open a terminal inside that folder:
+
+- **Linux / macOS:** Right-click the folder and choose *Open Terminal Here*, or just `cd` into it
+- **Windows:** Open the folder in File Explorer, right-click on an empty spot, and select *Open in PowerShell*
+
+To confirm you're in the right place, run:
+
+```bash
+pwd
+```
+
+The path it shows should match your folder. Then run `ls` (or `dir` on Windows PowerShell) to list the files in the folder and make sure `revanced-cli.jar` is actually there:
+
+```bash
+# Linux / macOS
+ls
+
+# Windows PowerShell
+dir
+```
+
+You should see `revanced-cli.jar` in the output. If you do, you're in the right place and ready to continue.
+
+---
+
+## Step 2: Download the Patch Bundle
+
+The patch bundle is a `.rvp` file that tells the CLI what patches are available and which apps they support.
+
+> **This file is downloaded directly from the official ReVanced API** — the exact same endpoint the ReVanced Manager app on Android uses to fetch patches. The ReVanced GitHub repo is currently unavailable and the GitLab mirror only has source code releases, so this API is the officially recommended source for the latest patch bundle.
+
+**Linux / macOS:**
+
+```bash
+wget "https://api.revanced.app/v5/patches.rvp"
+```
+
+**Windows:**
+
+Just open this URL in your browser and it'll download automatically. Move the downloaded file into the same folder you've been working in:
+
+```
+https://api.revanced.app/v5/patches.rvp
+```
+
+---
+
+## Step 3: Find the Right APK Version
+
+You can't patch just any version of an app. The patches are built for specific versions, so you need to find out which one to download. Run this command to see what's supported.
+
+**Linux / macOS (with grep):**
+
+```bash
+java -jar revanced-cli.jar list-versions \
+  -p patches.rvp \
+  -b | grep -A20 -E "com.google.android.youtube|com.google.android.apps.youtube.music"
+```
+
+The `|` inside the grep part means OR, so it'll show results for YouTube and YouTube Music at the same time. You can add more apps the same way.
+
+**Windows, or if you don't have grep:**
+
+```bash
+java -jar revanced-cli.jar list-versions -p patches.rvp -b
+```
+
+This dumps everything, so just scroll through and find your app manually. Write down the latest supported version number you see for it.
+
+Here are the package names to look for:
+
+| App | Package Name |
+|-----|-------------|
+| YouTube | `com.google.android.youtube` |
+| YouTube Music | `com.google.android.apps.youtube.music` |
+
+---
+
+## Step 4: Download the APK
+
+Go to [APKMirror](https://www.apkmirror.com/) and search for the app along with the version number you just noted. For example: `YouTube 20.14.43`.
+
+Before downloading, you need to pick the right file for your phone's CPU architecture. If you're not sure which one your phone uses, install the **CPU-Z** app from the Play Store and it'll tell you right away.
+
+| Architecture | Who it's for |
+|---|---|
+| `armeabi-v7a` (32-bit) | Older and budget phones, usually with 4 GB RAM or less |
+| `arm64-v8a` (64-bit) | Most phones made in the last few years |
+
+You might also see an option to download an "APK bundle" on APKMirror. Skip that and stick to the plain `.apk` file for your architecture.
+
+Once downloaded, move the APK into your working folder and give it a simple name:
+
+| App | Rename to |
+|-----|-----------|
+| YouTube | `youtube-latest.apk` |
+| YouTube Music | `yt-music-latest.apk` |
+| Any other app | Anything short and easy to remember |
+
+---
+
+## Step 5: Patch the APK
+
+**YouTube:**
+
+```bash
+java -jar revanced-cli.jar patch \
+  -p patches.rvp \
+  -b \
+  -o Patched-YouTube.apk \
+  youtube-latest.apk
+```
+
+**YouTube Music:**
+
+```bash
+java -jar revanced-cli.jar patch \
+  -p patches.rvp \
+  -b \
+  -o Patched-YTMusic.apk \
+  yt-music-latest.apk
+```
+
+**Any other app** (swap `APK_NAME.apk` for whatever you named your downloaded file):
+
+```bash
+java -jar revanced-cli.jar patch \
+  -p patches.rvp \
+  -b \
+  -o Patched.apk \
+  APK_NAME.apk
+```
+
+---
+
+## Step 6: Install GmsCore (MicroG)
+
+GmsCore is a free and open-source replacement for Google Play Services. It's required for any Google-related app patches to work, including YouTube, YouTube Music, and Google Photos. Without it, the patched apps simply won't function properly.
+
+We're using the version maintained by the ReVanced team themselves, so you know it's legit:
+
+1. Download the latest release from the [ReVanced GmsCore releases page](https://github.com/ReVanced/GmsCore/releases)
+2. Transfer it to your phone and install it (see Step 7 below if you hit an "Install blocked" error)
+3. Open GmsCore and sign in with your Google account
+
+---
+
+## Step 7: Install the Patched APK
+
+Transfer the patched APK (for example, `Patched-YouTube.apk`) to your phone however you like — Bluetooth, Google Drive, a USB cable, a messaging app, whatever works for you.
+
+Once it's on your phone, open it with a file manager and tap **Install**.
+
+**Getting an "Install blocked" or "Unknown source" message?**
+
+This just means your phone needs permission to install apps from outside the Play Store. Here's how to fix it:
+
+1. In the error dialog, tap **Settings** or **Allow from this source**
+2. Turn on the **"Install unknown apps"** permission for whichever app you used to open the APK (your file manager, browser, etc.)
+3. Go back and tap Install again
+
+---
+
+## Troubleshooting
+
+**See all supported app versions:**
+
+```bash
+java -jar revanced-cli.jar list-versions \
+  -p patches.rvp \
+  -b
+```
+
+**See all available patches:**
+
+```bash
+java -jar revanced-cli.jar list-patches \
+  -p patches.rvp \
+  -b
+```
+
+**Force patching an unsupported version:**
+
+If the exact version you need isn't available on APKMirror, you can try forcing the patch with the `-f` flag. It doesn't always work perfectly, but it's worth a shot.
+
+```bash
+java -jar revanced-cli.jar patch \
+  -f \
+  -p patches.rvp \
+  -b \
+  -o Patched-YouTube.apk \
+  youtube-latest.apk
+```
+
+---

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,8 @@
 # 💻 Documentation and guides of ReVanced CLI
-
 This documentation contains topics around [ReVanced CLI](https://github.com/revanced/revanced-cli).
 
 ## 📖 Table of contents
-
 1. [💼 Prerequisites](0_prerequisites.md)
 2. [🛠️ Using ReVanced CLI](1_usage.md)
+   - [🛠️ Using ReVanced CLI (Beginner Guide)](1b_usage_beginners.md)
 3. [🔨 Building ReVanced CLI](2_building.md)


### PR DESCRIPTION
## What this does

Adds a beginner friendly companion guide (`1b_usage_beginners.md`), updates `0_prerequisites.md` with clearer OS-specific instructions, and updates the table of contents to link to the new guide.

## Why this exists

I have an older, lower-end phone and the ReVanced Manager app kept failing every single time I tried to patch. Like a lot of people in that situation, I ended up looking at pre-patched APKs from third party sites. Some of them are probably fine, but you genuinely can't tell who built it, what's in it, or what a future update might quietly add. It started to feel like a bad idea.

I eventually found the CLI and figured out how to use it, but it took much longer than it should have. The existing docs assume you're already comfortable with the terminal and skip over a lot of things that trip up newer users. So I wrote the guide I wish had existed when I was figuring this out, and then figured this was worth contributing back.

## Changes

**`0_prerequisites.md`**
- Added OS-specific Java installation instructions for Windows (Eclipse Temurin / Adoptium, OpenJDK build), Fedora, Ubuntu/Debian/Mint/Pop!_OS/Elementary/Zorin, and Arch-based distros (Arch, CachyOS, EndeavourOS, Manjaro)
- Added `java -version` check commands so users can verify the install worked
- Added an extra link at the bottom of the "What's next" section pointing to the beginner guide, alongside the existing link to `1_usage.md`. This does not replace the existing link, just gives newcomers an alternative path

**`1b_usage_beginners.md`** (new file)

A full walkthrough written for someone who has never done this before. It covers:

- Downloading the patch bundle from `api.revanced.app/v5/patches.rvp`, which is the **only available source** for the `.rvp` file right now. The GitHub repo has been taken down and the GitLab mirror only hosts source code releases, not `.rvp` files. This is the exact same endpoint the ReVanced Manager app uses internally and is the recommended source. This is spelled out clearly in the guide because it's a genuine point of confusion for new users who go looking on GitHub and find nothing
- Finding the correct supported APK version before downloading anything
- A common mistake on APKMirror: accidentally downloading an APK bundle instead of a plain APK, and picking the wrong CPU architecture. The guide explains how to check your device architecture using CPU-Z and what each option means
- The full patching workflow for YouTube, YouTube Music, and any other app
- GmsCore setup, including why it's needed specifically for Google app patches
- Installing the patched APK by transferring it to the phone, and how to handle the "Install unknown apps" permission prompt without using ADB

**`README.md` (ToC)**
- Added `1b_usage_beginners.md` nested under `1_usage.md` in the table of contents

## Notes

- The tone of the new guide is intentionally more conversational than the existing docs. Happy to adjust if that doesn't fit the project style
- This is my first contribution to this repo. If anything needs to be restructured, renamed, or rewritten to fit better, just let me know and I'll sort it out